### PR TITLE
Added consumer groupId

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ n.PHONY: build, delete, deploy, docker, install, kind, fmt, vet, test
 # Remember to do "export DF_HOME=/path/to/data-fabric/" before running make build
 PROJECT_HOME=${PWD}
 REGISTRY=ghcr.io/raft-tech
-IMAGE=meilisearch-loader
-VERSION=latest
+IMAGE=df-meilisearch-loader
+VERSION=dev
 FULL_IMAGE=${REGISTRY}/${IMAGE}:${VERSION}
 KIND_CLUSTER=data-fabric
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,16 +1,17 @@
 package main
 
 import (
+	"meilisearch-loader/internal/kafka/consumer"
+	"meilisearch-loader/internal/meilisearch/producer"
+	"meilisearch-loader/internal/model"
 	"os"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	kafkaConfig "meilisearch-loader/internal/kafka/configs"
-	"meilisearch-loader/internal/kafka/consumer"
+
 	meiliConfig "meilisearch-loader/internal/meilisearch/configs"
-	"meilisearch-loader/internal/meilisearch/producer"
-	"meilisearch-loader/internal/model"
 )
 
 func main() {
@@ -26,13 +27,13 @@ func main() {
 		log.Fatal().Msgf(err.Error())
 	}
 
-	kafkaCfg := kafkaConfig.NewConfig()
+	kafkaCfg := kafkaConfig.NewConfig(meiliCfg.Index)
 
 	var kafkaConsumer consumer.DeserializingAvroConsumer
 	if kafkaCfg.SaslMechanism == "" {
-		kafkaConsumer = consumer.NewNoAuth(kafkaCfg.BrokerHost, kafkaCfg.SchemaRegUrl, kafkaCfg.Topic)
+		kafkaConsumer = consumer.NewNoAuth(kafkaCfg.BrokerHost, kafkaCfg.SchemaRegUrl, kafkaCfg.Topic, kafkaCfg.GroupId)
 	} else {
-		kafkaConsumer = consumer.NewSaslAuth(kafkaCfg.BrokerHost, kafkaCfg.SchemaRegUrl, kafkaCfg.Topic, kafkaCfg.SaslMechanism, kafkaCfg.SaslUsername, kafkaCfg.SaslSecret)
+		kafkaConsumer = consumer.NewSaslAuth(kafkaCfg.BrokerHost, kafkaCfg.SchemaRegUrl, kafkaCfg.Topic, kafkaCfg.GroupId, kafkaCfg.SaslMechanism, kafkaCfg.SaslUsername, kafkaCfg.SaslSecret)
 	}
 	defer kafkaConsumer.KafkaClient.Close()
 

--- a/internal/kafka/configs/config_test.go
+++ b/internal/kafka/configs/config_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestConfig_Defaults(t *testing.T) {
+	indexName := ""
 	data := []struct {
 		name     string
 		expected string
@@ -14,10 +15,11 @@ func TestConfig_Defaults(t *testing.T) {
 		{"SchemaRegUrl", "localhost:8081"},
 		{"Topic", "test-topic"},
 		{"SaslMechanism", ""},
+		{"GroupId", "df-meilisearch"},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
-			c := NewConfig()
+			c := NewConfig(indexName)
 			if result := getField(c, d.name); result != d.expected {
 				t.Errorf("Expected %s, got %s", d.expected, result)
 			}
@@ -26,6 +28,7 @@ func TestConfig_Defaults(t *testing.T) {
 }
 
 func TestConfig_Envs(t *testing.T) {
+	indexName := "testIndex"
 	data := []struct {
 		name     string
 		env      string
@@ -35,11 +38,12 @@ func TestConfig_Envs(t *testing.T) {
 		{"SchemaRegUrl", "SCHEMA_REGISTRY_URL", "customhost:8081"},
 		{"Topic", "KAFKA_TOPIC", "custom-topic"},
 		{"SaslMechanism", "KAFKA_SASL_MECHANISM", "SCRAM-SHA-512"},
+		{"GroupId", "KAFKA_CLIENT_CONSUMER_GROUPID", "test-consumer-group"},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
 			t.Setenv(d.env, d.envValue)
-			c := NewConfig()
+			c := NewConfig(indexName)
 			if result := getField(c, d.name); result != d.envValue {
 				t.Errorf("Expected %s, got %s", d.envValue, result)
 			}

--- a/internal/meilisearch/configs/config.go
+++ b/internal/meilisearch/configs/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Index           string
 	IndexPrimaryKey string
 	Url             string
+	GroupID         string
 }
 
 const (


### PR DESCRIPTION
**What:**

Added consumer groups to to meilisearch loaders.

**Related Issues:**
Closes #10 

## Validation

- Enable meilisearch on meilisearch https://github.com/raft-tech/data-fabric/blob/ff1139ea2b0f1dbe2fbea242395cc52db60cf02a/kubernetes/defaults/meilisearch.yaml#L1
- Stand up `data-fabric` using `dfdev cluster recreate -u df.local`
- Grab this branch and build meilisearch loeader
```bash
make docker && make kind
```
- Restart meilisearch loaders pods running by scaling or deleting the pods.
- Use kafka-ui to list consumers registered to kafka. You should seem something long the lines of 
![image](https://github.com/raft-tech/df-meilisearch-loader/assets/97757567/45e4321a-e25e-4dfc-80d9-3dccd9eb1e1d)